### PR TITLE
Round min/max disparities before casting them to int

### DIFF
--- a/mgm_costvolume.cc
+++ b/mgm_costvolume.cc
@@ -65,7 +65,7 @@ struct costvolume_t allocate_costvolume (struct Img min, struct Img max)
    struct costvolume_t cv;
    cv.vectors = std::vector< Dvec >(min.npix);
    for (int i=0;i< min.npix;i++) {
-      cv[i].init(min[i], max[i]);
+      cv[i].init(floorf(min[i]), ceilf(max[i]));
    }
 
    return cv;


### PR DESCRIPTION
This modification prevents the situation where min/max disparities become equal at some low scale because they are both casted to the same integer, causing [this assert](https://github.com/gfacciol/mgm/blob/f9713b690a2fc328c64c4cc88eba1d1c8e238c06/dvec.cc#L57) to fail.

For example

    git clone -b multiscale https://github.com/gfacciol/mgm.git
    cd mgm
    git checkout 1e834fe
    make CFLAGS=-O3
    ./mgm_multi -r -1 -R 1 -S 1 data/fountain23-im?.png d.tif

should fail with

> 1/1 350x250	maxrange: -0.500000 0.500000
> Assertion failed: (min<max), function init, file ./dvec.cc, line 57.

This happens because -1 and 1 become -0.5 and 0.5 after division by 2 at scale 1, and after cast to `int` they become 0 and 0, causing the assert to fail. Rounding them with `floorf` and `ceilf` before passing them to the cost volume `init` function should fix the issue.

This should also fix https://github.com/cmla/s2p/issues/20.